### PR TITLE
Add GitHub Pages deployment

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -1,0 +1,34 @@
+name: Deploy to GitHub Pages
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  gh-pages:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup GitHub Pages
+        uses: actions/configure-pages@v2
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v18
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Install Nix dependencies
+        run: nix-shell --run true
+
+      - name: Build into public/
+        run: nix-shell --run 'npm run build'
+
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: public/
+          git-config-name: "github-actions[bot]"
+          git-config-email: "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
Usage:

1. Enable GitHub Pages:
    1. Go to the repository's *Settings*, then *Pages*.
    2. Make sure the *Source* is *Deploy from a branch* and the *Branch* is `main`.
2. Re-run the GitHub Pages workflow:
    1. Go to *Actions*.
    2. Choose the *Deploy to GitHub Pages* workflow.
    3. Click *Run workflow* (on the right-hand side).
    4. Wait until the new workflow is done (you might need to refresh a few times).
3. Switch GitHub Pages to the right branch:
    1. Go back to the repository's *Settings*, then *Pages*.
    2. Make sure the *Source* is *Deploy from a branch* and the *Branch* is `gh-pages`.